### PR TITLE
Use `av-data` version 0.3.0 and fix errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["opus"]
 edition = "2018"
 
 [dependencies]
-av-bitstream = { version = "0.1.0", git = "https://github.com/rust-av/rust-av" }
+av-bitstream = "0.1.0"
 av-codec = "0.2.0"
-av-data = "0.2.0"
+av-data = "0.3.0"
 num-complex = "0.2"
 log = "0.4"
 integer-sqrt = "0.1.2"


### PR DESCRIPTION
Hello.

Rust rookie here- and I was just trying to build opus and it produced this error:

```bash
error[E0053]: method `send_packet` has an incompatible type for trait
  --> src/decoder.rs:44:40
   |
44 |         fn send_packet(&mut self, pkt: &AVPacket) -> Result<()> {
   |                                        ^^^^^^^^^
   |                                        |
   |                                        expected struct `av_data::packet::Packet`, found struct `data::packet::Packet`
   |                                        help: change the parameter type to match the trait: `&av_data::packet::Packet`
   |
   = note: expected fn pointer `fn(&mut Dec, &av_data::packet::Packet) -> std::result::Result<_, _>`
              found fn pointer `fn(&mut Dec, &data::packet::Packet) -> std::result::Result<_, _>`

error[E0053]: method `receive_frame` has an incompatible type for trait
   --> src/decoder.rs:129:40
    |
129 |         fn receive_frame(&mut self) -> Result<ArcFrame> {
    |                                        ^^^^^^^^^^^^^^^^
    |                                        |
    |                                        expected struct `av_data::frame::Frame`, found struct `Frame`
    |                                        help: change the output type to match the trait: `std::result::Result<Arc<av_data::frame::Frame>, codec::error::Error>`
    |
    = note: expected fn pointer `fn(&mut Dec) -> std::result::Result<Arc<av_data::frame::Frame>, _>`
               found fn pointer `fn(&mut Dec) -> std::result::Result<Arc<Frame>, _>`

For more information about this error, try `rustc --explain E0053`.
warning: `opus` (lib) generated 3 warnings
error: could not compile `opus` due to 2 previous errors; 3 warnings emitted
```

I used `0.3.0` of `av-data` and that seemed to fix it. So, I thought I'll leave a PR and let you know or see what you think.

Thanks!